### PR TITLE
VP-3634: Add redis service

### DIFF
--- a/argocd-config/base/redis.yaml
+++ b/argocd-config/base/redis.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: redis
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/virtocommerce/vc-deploy-infra
+    targetRevision: HEAD
+    path: redis
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: redis
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true  

--- a/argocd-config/kustomization.yaml
+++ b/argocd-config/kustomization.yaml
@@ -9,5 +9,5 @@ resources:
 - base/tenant-app-project.yaml
 - base/tenant-project.yaml
 - base/demo-tenant-project.yaml
-
+- base/redis.yaml
 - base/apps-config.yaml

--- a/redis/redis-master-deployment.yaml
+++ b/redis/redis-master-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1 
+kind: Deployment
+metadata:
+  name: redis-master
+spec:
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      containers:
+      - name: master
+        image: redis:5.0.9
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379
+            
+          
+              
+        
+
+

--- a/redis/redis-svc.yaml
+++ b/redis/redis-svc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis


### PR DESCRIPTION
### Problem
Currently we don’t have redis for solution in linux, which is delivering through Argo CD.

### Solution
Add a basic redis service based on the stable official linux image (redis:5.0.9)

### Proposed of changes
- Add namespace for redis
- Apply manifest ( /argocd-config/base/redis.yaml ) to build Redis applications

