### PR TITLE
VP-3634: Add password for redis service

### DIFF
--- a/redis/redis-master-deployment.yaml
+++ b/redis/redis-master-deployment.yaml
@@ -19,13 +19,21 @@ spec:
       containers:
       - name: master
         image: redis:5.0.9
+        args: ["--requirepass", "$(REDIS_PASS)"]
         resources:
           requests:
             cpu: 100m
             memory: 100Mi
         ports:
         - containerPort: 6379
-            
+        env:
+          - name: MASTER
+            value: "true"
+          - name: REDIS_PASS
+            valueFrom:
+              secretKeyRef:
+                name: redis
+                key: REDIS_PASS
           
               
         


### PR DESCRIPTION
### Problem
The redis service does not have a password

### Solution
Add password for redis service

### Necessary:

Need to generate kubernetes secrets for all namespaces

```
kubectl create secret generic redis --from-literal=REDIS_PASS="SOME_PASSWORD"
```
