### PR TITLE
VP-4553: Add reloader service

### DIFF
--- a/argocd-config/base/reloader.yaml
+++ b/argocd-config/base/reloader.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: reloader
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/virtocommerce/vc-deploy-infra
+    targetRevision: HEAD
+    path: reloader
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true  

--- a/reloader/reloader.yaml
+++ b/reloader/reloader.yaml
@@ -1,0 +1,116 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: reloader-reloader
+    chart: "reloader-v0.0.68"
+    release: "reloader"
+    heritage: "Tiller"
+  name: reloader-reloader-role
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - deployments
+      - daemonsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: reloader-reloader
+    chart: "reloader-v0.0.68"
+    release: "reloader"
+    heritage: "Tiller"
+  name: reloader-reloader-role-binding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: reloader-reloader-role
+subjects:
+  - kind: ServiceAccount
+    name: reloader-reloader
+    namespace: default
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: reloader-reloader
+    chart: "reloader-v0.0.68"
+    release: "reloader"
+    heritage: "Tiller"
+    group: com.stakater.platform
+    provider: stakater
+    version: v0.0.68
+    
+  name: reloader-reloader
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: reloader-reloader
+      release: "reloader"
+  template:
+    metadata:
+      labels:
+        app: reloader-reloader
+        chart: "reloader-v0.0.68"
+        release: "reloader"
+        heritage: "Tiller"
+        group: com.stakater.platform
+        provider: stakater
+        version: v0.0.68
+        
+    spec:
+      containers:
+      - image: "stakater/reloader:v0.0.68"
+        imagePullPolicy: IfNotPresent
+        name: reloader-reloader
+      securityContext: 
+        runAsNonRoot: true
+        runAsUser: 65534
+        
+      serviceAccountName: reloader-reloader
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: reloader-reloader
+    chart: "reloader-v0.0.68"
+    release: "reloader"
+    heritage: "Tiller"
+  name: reloader-reloader


### PR DESCRIPTION
### Problem
After updating configmap there is no way to automatically update deployment

### Solution
Using a nice tool to reload deployment
> https://github.com/stakater/Reloader

### Proposed of changes

Add the Reloader service that allows you to use the annotation below to reload the deployment when the modules-cm configmap was changed. For example, this allows you to store a modules.json in configmap and do not use an additional hash to update the app

```
template:
    metadata:
      annotations:
         ...
           configmap.reloader.stakater.com/reload: "modules-cm"
         ...
```
<img width="967" alt="Screenshot 2020-09-09 at 16 30 05" src="https://user-images.githubusercontent.com/66745418/92612200-ef8ba780-f2b9-11ea-8125-832f920ed97b.png">
<img width="193" alt="Screenshot 2020-09-09 at 16 30 30" src="https://user-images.githubusercontent.com/66745418/92612236-f9150f80-f2b9-11ea-9b88-6f53a462b83a.png">
